### PR TITLE
Improve repository tree UI controls

### DIFF
--- a/app/assets/styles/app.css
+++ b/app/assets/styles/app.css
@@ -5,10 +5,13 @@ body {
 
 .repo-tree-canvas svg {
     width: 100%;
+    min-width: 100%;
+    display: block;
 }
 
 .repo-tree-canvas {
     min-height: 360px;
+    overflow: auto;
 }
 
 .repo-tree-canvas .link {

--- a/app/templates/repository/_tree_view.html.twig
+++ b/app/templates/repository/_tree_view.html.twig
@@ -2,9 +2,13 @@
      data-controller="repository-tree"
      data-repository-tree-tree-value='{{ treeData|json_encode|e('html_attr') }}'
      data-repository-tree-enqueue-url-template-value="{{ path('ingestion_queue_enqueue', {id: 'NODE_ID'}) }}"
+     data-repository-tree-filter-storage-key-value="repository-tree-filter"
      data-repository-tree-translations-value='{{ {
          enqueueLabel: 'ingestion.queue.actions.enqueue'|trans,
+         retryLabel: 'ingestion.queue.actions.retry'|trans,
          disabledReason: 'ingestion.queue.labels.disabled'|trans,
+         inProgressReason: 'ingestion.queue.labels.in_progress'|trans,
+         indexedReason: 'ingestion.queue.labels.indexed'|trans,
          folderHint: 'ingestion.queue.labels.folder_not_eligible'|trans,
          ingestion: {
              queued: 'ingestion.status.queued'|trans,
@@ -51,7 +55,35 @@
                     <span class="ms-1">{{ 'repository.tree.reset'|trans }}</span>
                 </button>
             </div>
-            <div class="text-muted small">{{ 'repository.tree.helper'|trans }}</div>
+            <div class="d-flex flex-wrap align-items-center gap-2">
+                <div class="btn-group" role="group" aria-label="{{ 'repository.tree.filters.label'|trans }}">
+                    <button class="btn btn-outline-primary btn-sm" type="button"
+                            data-repository-tree-target="filterButton"
+                            data-action="repository-tree#setFilter"
+                            data-repository-tree-filter-param="all">
+                        {{ 'repository.tree.filters.all'|trans }}
+                    </button>
+                    <button class="btn btn-outline-primary btn-sm" type="button"
+                            data-repository-tree-target="filterButton"
+                            data-action="repository-tree#setFilter"
+                            data-repository-tree-filter-param="indexable">
+                        {{ 'repository.tree.filters.indexable'|trans }}
+                    </button>
+                    <button class="btn btn-outline-primary btn-sm" type="button"
+                            data-repository-tree-target="filterButton"
+                            data-action="repository-tree#setFilter"
+                            data-repository-tree-filter-param="indexed">
+                        {{ 'repository.tree.filters.indexed'|trans }}
+                    </button>
+                    <button class="btn btn-outline-primary btn-sm" type="button"
+                            data-repository-tree-target="filterButton"
+                            data-action="repository-tree#setFilter"
+                            data-repository-tree-filter-param="failed">
+                        {{ 'repository.tree.filters.failed'|trans }}
+                    </button>
+                </div>
+                <div class="text-muted small">{{ 'repository.tree.helper'|trans }}</div>
+            </div>
         </div>
         <div class="row g-4">
             <div class="col-lg-12">

--- a/app/translations/messages.fr.yaml
+++ b/app/translations/messages.fr.yaml
@@ -97,6 +97,12 @@ repository:
     collapse_all: "Replier"
     reset: "Réinitialiser"
     helper: "Chaque noeud reste sélectionnable pour lui associer des actions ciblées."
+    filters:
+      label: "Filtres de l'arbre"
+      all: "Tous"
+      indexable: "Indexables"
+      indexed: "Indexés"
+      failed: "En échec"
     details:
       title: "Détails du noeud"
       subtitle: "Sélectionnez un dossier ou un fichier dans l'arbre pour afficher ses métadonnées."
@@ -123,6 +129,8 @@ ingestion:
       empty: "Aucun élément dans la file."
       none: "—"
       disabled: "Document déjà en file ou en cours."
+      in_progress: "Document déjà dans la file ou en cours de traitement."
+      indexed: "Document déjà indexé."
       folder_not_eligible: "Les dossiers ne peuvent pas être ajoutés à la file."
     fields:
       path: "Chemin"
@@ -135,6 +143,7 @@ ingestion:
       storage_path: "Chemin de stockage"
     actions:
       enqueue: "Ajouter à la file"
+      retry: "Réessayer"
     confirm:
       delete: "Supprimer cet élément ?"
     flash:


### PR DESCRIPTION
## Summary
- add persistent tree filters and align enqueue actions with ingestion status (including retry)
- improve tree rendering with truncated labels, tooltips, and scrollable canvas to avoid clipping
- adjust styling for tree canvas overflow handling

## Testing
- npm run build


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692d76c34a348322bc05ffe49426e623)